### PR TITLE
cacheIndex res already parsed before - return undefined

### DIFF
--- a/translate-json
+++ b/translate-json
@@ -72,7 +72,7 @@ if (process.argv.length >= 4) {
                         prom = translate(value, { to: languageKey })
                     }
                     
-                    return prom.then((res) => cachedIndex(value, res.text, languageKey))
+                    return prom.then((res) => cachedIndex(value, res, languageKey))
                     .catch((err) => console.log(err))
                     .then((text) => {
                         //Sets the value in the accumulator


### PR DESCRIPTION
run with api-key provided but return empty json and undefined translation in cache

This PR, fixed return undefined in cache file and empty json value

![image](https://user-images.githubusercontent.com/25372728/88245197-7cee4a80-ccc0-11ea-8d6d-9a276cddad7f.png)

to 

![image](https://user-images.githubusercontent.com/25372728/88245211-92fc0b00-ccc0-11ea-8cb6-608fb84f38c3.png)
